### PR TITLE
fix: standardize app list layout in Herramientas

### DIFF
--- a/app/herramientas/page.tsx
+++ b/app/herramientas/page.tsx
@@ -899,8 +899,8 @@ export default function HerramientasPage() {
           {currentStep === 4 && (
             <div className="space-y-6">
               <Card className="border-orange-200 dark:border-orange-800 bg-orange-50/30 dark:bg-orange-950/30">
-                <CardHeader className="text-center">
-                  <CardTitle className="text-2xl flex items-center justify-center gap-2">
+                <CardHeader>
+                  <CardTitle className="text-2xl flex items-center gap-2">
                     <Smartphone className="h-8 w-8 text-orange-500" />
                     Tecnología: Apps y Herramientas Digitales
                   </CardTitle>
@@ -925,8 +925,8 @@ export default function HerramientasPage() {
                       <CardContent>
                         <Accordion type="single" collapsible className="w-full">
                           <AccordionItem value="task-apps">
-                            <AccordionTrigger>
-                              <div className="flex items-center gap-2">
+                            <AccordionTrigger className="text-left">
+                              <div className="flex items-center gap-2 w-full">
                                 <CheckCircle className="h-4 w-4" />
                                 Apps de Tareas y Productividad
                               </div>
@@ -1063,14 +1063,17 @@ export default function HerramientasPage() {
                                         Google Keep
                                       </a>
                                     </h5>
-                                    <p className="text-xs text-muted-foreground mb-1">
+                                    <p className="text-xs text-muted-foreground mb-2">
                                       Notas visuales con colores
                                     </p>
-                                    <ul className="text-xs space-y-1">
-                                      <li>• Notas por voz</li>
-                                      <li>• Recordatorios por ubicación</li>
-                                      <li>• Colaborativo</li>
-                                    </ul>
+                                    <div className="flex gap-1">
+                                      <Badge variant="outline" className="text-xs">
+                                        Gratis
+                                      </Badge>
+                                      <Badge variant="outline" className="text-xs">
+                                        Colaborativo
+                                      </Badge>
+                                    </div>
                                   </div>
                                   <div className="p-3 border rounded">
                                     <h5 className="font-semibold text-sm mb-1">
@@ -1083,14 +1086,17 @@ export default function HerramientasPage() {
                                         Notion
                                       </a>
                                     </h5>
-                                    <p className="text-xs text-muted-foreground mb-1">
+                                    <p className="text-xs text-muted-foreground mb-2">
                                       All-in-one workspace
                                     </p>
-                                    <ul className="text-xs space-y-1">
-                                      <li>• Plantillas TDAH</li>
-                                      <li>• Bases de datos relacionales</li>
-                                      <li>• Muy personalizable</li>
-                                    </ul>
+                                    <div className="flex gap-1">
+                                      <Badge variant="outline" className="text-xs">
+                                        Freemium
+                                      </Badge>
+                                      <Badge variant="outline" className="text-xs">
+                                        Flexible
+                                      </Badge>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1098,14 +1104,14 @@ export default function HerramientasPage() {
                           </AccordionItem>
 
                           <AccordionItem value="blocker-apps">
-                            <AccordionTrigger>
-                              <div className="flex items-center gap-2">
+                            <AccordionTrigger className="text-left">
+                              <div className="flex items-center gap-2 w-full">
                                 <Focus className="h-4 w-4" />
                                 Bloqueadores de Distracciones
                               </div>
                             </AccordionTrigger>
                             <AccordionContent>
-                              <div className="grid md:grid-cols-1 gap-4">
+                              <div className="grid md:grid-cols-2 gap-4">
                                 <div className="space-y-3">
                                   <div className="p-3 border rounded">
                                     <h5 className="font-semibold text-sm mb-1">
@@ -1118,15 +1124,20 @@ export default function HerramientasPage() {
                                         Cold Turkey
                                       </a>
                                     </h5>
-                                    <p className="text-xs text-muted-foreground mb-1">
+                                    <p className="text-xs text-muted-foreground mb-2">
                                       Bloqueo robusto, difícil de desactivar
                                     </p>
-                                    <ul className="text-xs space-y-1">
-                                      <li>• Horarios programados</li>
-                                      <li>• Bloqueo de aplicaciones</li>
-                                      <li>• Modo extremo disponible</li>
-                                    </ul>
+                                    <div className="flex gap-1">
+                                      <Badge variant="outline" className="text-xs">
+                                        Freemium
+                                      </Badge>
+                                      <Badge variant="outline" className="text-xs">
+                                        Modo extremo
+                                      </Badge>
+                                    </div>
                                   </div>
+                                </div>
+                                <div className="space-y-3">
                                   <div className="p-3 border rounded">
                                     <h5 className="font-semibold text-sm mb-1">
                                       <a
@@ -1138,14 +1149,17 @@ export default function HerramientasPage() {
                                         Freedom
                                       </a>
                                     </h5>
-                                    <p className="text-xs text-muted-foreground mb-1">
+                                    <p className="text-xs text-muted-foreground mb-2">
                                       Multiplataforma
                                     </p>
-                                    <ul className="text-xs space-y-1">
-                                      <li>• Sincroniza dispositivos</li>
-                                      <li>• Listas predefinidas</li>
-                                      <li>• Estadísticas de uso</li>
-                                    </ul>
+                                    <div className="flex gap-1">
+                                      <Badge variant="outline" className="text-xs">
+                                        Pago
+                                      </Badge>
+                                      <Badge variant="outline" className="text-xs">
+                                        Sincroniza dispositivos
+                                      </Badge>
+                                    </div>
                                   </div>
                                 </div>
                               </div>


### PR DESCRIPTION
## Summary
- align task-app trigger to left
- standardize Bloqueadores de Distracciones entries with descriptions and badges

## Testing
- `bun lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e6ea7a1c832eac6d55369a2bcbcc