### PR TITLE
Remove Alfa Beta as a medication pricing source

### DIFF
--- a/app/api/medicamentos-precios/route.ts
+++ b/app/api/medicamentos-precios/route.ts
@@ -5,7 +5,6 @@ import type { Medicamento } from "@/lib/medicamentos/types";
 // Configuración simple
 const FARMACITY_API =
   "https://appfarmacitymicroservice-prod.azurewebsites.net/api/Medicine/search";
-const ALFABETA_LUDOXA_URL = "https://www.alfabeta.net/precio/ludoxa.html";
 const TIMEOUT = 25000;
 const CACHE_TTL = 15 * 60 * 1000; // 15 minutos
 
@@ -43,12 +42,6 @@ interface FarmacityMed {
   };
   barCode?: string;
   id?: string | number;
-}
-
-interface AlfabetaProducto {
-  descripcion: string;
-  precio: number;
-  fecha?: string;
 }
 
 function normalizarNumeroFarmacity(valor: string | number | undefined): number {
@@ -152,98 +145,6 @@ async function obtenerMedicamentos(termino: string): Promise<FarmacityMed[]> {
   }
 }
 
-function normalizarPrecioAlfabeta(valor: string): number {
-  const normalizado = valor.replace(/\./g, "").replace(",", ".").trim();
-  const numero = Number.parseFloat(normalizado);
-  return Number.isFinite(numero) ? numero : 0;
-}
-
-function parseFechaAlfabeta(fecha?: string): string {
-  if (!fecha) {
-    return new Date().toISOString();
-  }
-
-  const match = fecha.match(/(\d{2})\/(\d{2})\/(\d{2})/);
-  if (!match) {
-    return new Date().toISOString();
-  }
-
-  const [, dd, mm, yy] = match;
-  const iso = new Date(
-    Number(`20${yy}`),
-    Number(mm) - 1,
-    Number(dd)
-  ).toISOString();
-
-  return iso;
-}
-
-function parseProductosAlfabeta(html: string): AlfabetaProducto[] {
-  const productos: AlfabetaProducto[] = [];
-  const regexFila =
-    /<td class="tddesc">([^<]+)<span[^>]*><\/span><\/td><td class="tdprecio">\$(.*?)<\/td><td class="tdfecha">\((.*?)\)<\/td>/g;
-
-  let match = regexFila.exec(html);
-
-  while (match) {
-    const descripcion = match[1]?.trim();
-    const precio = normalizarPrecioAlfabeta(match[2] || "");
-    const fecha = match[3]?.trim();
-
-    if (descripcion && precio > 0) {
-      productos.push({ descripcion, precio, fecha });
-    }
-
-    match = regexFila.exec(html);
-  }
-
-  return productos;
-}
-
-async function obtenerLisdexanfetaminaAlfabeta(): Promise<Medicamento[]> {
-  try {
-    console.log("🌐 Consultando Alfa Beta (Ludoxa)...");
-    const response = await fetchWithTimeout(ALFABETA_LUDOXA_URL, {
-      method: "GET",
-      headers: {
-        Accept: "text/html,application/xhtml+xml",
-        "User-Agent": "Mozilla/5.0 (compatible; TDAH-Argentina/1.0)",
-      },
-    });
-
-    if (!response.ok) {
-      console.warn(`⚠️ Alfa Beta respondió ${response.status}`);
-      return [];
-    }
-
-    const html = await response.text();
-    const productos = parseProductosAlfabeta(html);
-
-    if (productos.length === 0) {
-      console.warn("⚠️ No se pudieron parsear presentaciones desde Alfa Beta");
-      return [];
-    }
-
-      return productos.map((producto) => ({
-      codigo: `alfabeta_ludoxa_${producto.descripcion
-        .toLowerCase()
-        .replace(/\s+/g, "_")
-        .replace(/[^a-z0-9_]/g, "")}`,
-        nombre: "lisdexanfetamina",
-        marca: "Ludoxa",
-        laboratorio: "Adium",
-        source: "alfabeta",
-        precio: producto.precio,
-        presentacion: producto.descripcion,
-        concentracion: producto.descripcion.split(" x ")[0]?.trim() || "No especificado",
-        fechaActualizacion: parseFechaAlfabeta(producto.fecha),
-    }));
-  } catch (error) {
-    console.error("❌ Error consultando Alfa Beta:", error);
-    return [];
-  }
-}
-
 // Convertir medicamento
 function convertirMedicamento(med: FarmacityMed): Medicamento {
   const nombre = med.formula?.description || med.description || "Medicamento";
@@ -330,9 +231,6 @@ async function obtenerMedicamentosTDAH(): Promise<Medicamento[]> {
       }
     });
   });
-
-  const lisdexDesdeAlfabeta = await obtenerLisdexanfetaminaAlfabeta();
-  resultados.push(...lisdexDesdeAlfabeta);
 
   const medicamentosUnicos = eliminarDuplicados(resultados);
 

--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -144,10 +144,10 @@ export default function PreciosPage() {
       <Header />
 
       {/* Header Section */}
-      <PageHero
-        title="Precios de medicamentos"
-        description="Precios actualizados de Farmacity y Alfa Beta para medicamentos de TDAH"
-      >
+        <PageHero
+          title="Precios de medicamentos"
+          description="Precios actualizados de Farmacity para medicamentos de TDAH"
+        >
         {/* Info rápida */}
         {estadisticas && (
           <div className="mb-6 flex justify-center">
@@ -226,9 +226,8 @@ export default function PreciosPage() {
                         <strong>Importante:</strong> Otros estimulantes como
                         Adderall (anfetamina mixta) y Vyvanse (lisdexanfetamina)
                         están aprobados por la FDA para TDAH. En Argentina,
-                        actualmente solo se comercializa metilfenidato, pero se
-                        espera que la lisdexanfetamina comience su
-                        comercialización en abril de 2026.
+                        actualmente se comercializan metilfenidato y
+                        lisdexanfetamina.
                       </AlertDescription>
                     </Alert>
 

--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -223,10 +223,11 @@ export default function PreciosPage() {
                     <Alert className="mb-6 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950 max-w-full overflow-hidden border-2">
                       <AlertCircle className="h-4 w-4 text-blue-600" />
                       <AlertDescription className="text-blue-800 dark:text-blue-200 break-words">
-                        <strong>Importante:</strong> En Argentina actualmente
-                        se comercializan metilfenidato y lisdexanfetamina
-                        (incluyendo Vyvanse). Adderall (anfetamina mixta) sigue
-                        sin comercialización local.
+                        <strong>Importante:</strong> Otros estimulantes como
+                        Adderall (anfetamina mixta) están aprobados por la FDA
+                        para TDAH. En Argentina, actualmente solo se
+                        comercializa metilfenidato (Concerta, Ritalin) y
+                        lisdexanfetamina (Vyvanse).
                       </AlertDescription>
                     </Alert>
 

--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -223,11 +223,10 @@ export default function PreciosPage() {
                     <Alert className="mb-6 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950 max-w-full overflow-hidden border-2">
                       <AlertCircle className="h-4 w-4 text-blue-600" />
                       <AlertDescription className="text-blue-800 dark:text-blue-200 break-words">
-                        <strong>Importante:</strong> Otros estimulantes como
-                        Adderall (anfetamina mixta) y Vyvanse (lisdexanfetamina)
-                        están aprobados por la FDA para TDAH. En Argentina,
-                        actualmente se comercializan metilfenidato y
-                        lisdexanfetamina.
+                        <strong>Importante:</strong> En Argentina actualmente
+                        se comercializan metilfenidato y lisdexanfetamina
+                        (incluyendo Vyvanse). Adderall (anfetamina mixta) sigue
+                        sin comercialización local.
                       </AlertDescription>
                     </Alert>
 

--- a/lib/medicamentos/source-label.js
+++ b/lib/medicamentos/source-label.js
@@ -1,5 +1,5 @@
 function getMedicamentoSourceLabel(source) {
-  return source === "alfabeta" ? "Alfa Beta" : "Farmacity";
+  return source === "farmacity" ? "Farmacity" : source;
 }
 
 module.exports = { getMedicamentoSourceLabel };

--- a/lib/medicamentos/source-label.test.mjs
+++ b/lib/medicamentos/source-label.test.mjs
@@ -6,5 +6,5 @@ const { getMedicamentoSourceLabel } = sourceLabel;
 
 test("maps medicamento source to the correct badge label", () => {
   assert.equal(getMedicamentoSourceLabel("farmacity"), "Farmacity");
-  assert.equal(getMedicamentoSourceLabel("alfabeta"), "Alfa Beta");
+  assert.equal(getMedicamentoSourceLabel("desconocido"), "desconocido");
 });

--- a/lib/medicamentos/types.ts
+++ b/lib/medicamentos/types.ts
@@ -3,7 +3,7 @@ export interface Medicamento {
   nombre: string;
   marca: string;
   laboratorio: string;
-  source: "farmacity" | "alfabeta";
+  source: "farmacity";
   precio: number;
   presentacion: string;
   concentracion: string;


### PR DESCRIPTION
### Motivation
- Lisdexanfetamina pricing is available from Farmacity so the Alfa Beta scraping/parsing flow is no longer needed.
- Simplify the pricing pipeline to rely solely on Farmacity data and remove brittle HTML scraping code.

### Description
- Remove Alfa Beta URL, parsing helpers and the `obtenerLisdexanfetaminaAlfabeta` fetch/merge step from `app/api/medicamentos-precios/route.ts` so results come only from Farmacity.
- Restrict `Medicamento.source` to `"farmacity"` in `lib/medicamentos/types.ts`.
- Update `lib/medicamentos/source-label.js` to return the provided source for unknown values and adjust the unit test in `lib/medicamentos/source-label.test.mjs` accordingly.
- Update UI copy in `app/precios/page.tsx` to remove Alfa Beta mentions and reflect that lisdexanfetamina is commercialized.

### Testing
- Ran unit test: `node --test lib/medicamentos/source-label.test.mjs`, which passed.
- Ran linter: `npm run lint`, which reported no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7da1528ac832ca9e2a4dc015c4572)