### PR TITLE
Reorder stimulant price groups: lisdexanfetamina before metilfenidato

### DIFF
--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -84,6 +84,30 @@ export default function PreciosPage() {
     [medicamentosFiltrados]
   );
 
+  const estimulantesOrdenados = useMemo(() => {
+    const orden = ["lisdexanfetamina", "metilfenidato"];
+    const entries = Object.entries(medicamentosAgrupados.estimulantes);
+
+    return entries.sort(([a], [b]) => {
+      const indexA = orden.indexOf(a);
+      const indexB = orden.indexOf(b);
+
+      if (indexA === -1 && indexB === -1) {
+        return a.localeCompare(b, "es", { sensitivity: "base" });
+      }
+
+      if (indexA === -1) {
+        return 1;
+      }
+
+      if (indexB === -1) {
+        return -1;
+      }
+
+      return indexA - indexB;
+    });
+  }, [medicamentosAgrupados.estimulantes]);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white dark:from-slate-900 dark:to-slate-800">
@@ -299,7 +323,7 @@ export default function PreciosPage() {
                       </AlertDescription>
                     </Alert>
 
-                    {Object.entries(medicamentosAgrupados.estimulantes).map(
+                    {estimulantesOrdenados.map(
                       ([principio, meds]) => (
                         <div key={principio} className="mb-8">
                           <h3 className="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-200">


### PR DESCRIPTION
### Motivation
- Make the grouped "Estimulantes" prices view present `lisdexanfetamina` first and `metilfenidato` second to match the requested ordering and improve clarity for users.

### Description
- Add an `estimulantesOrdenados` `useMemo` in `app/precios/page.tsx` that sorts stimulant group entries using the explicit order `["lisdexanfetamina","metilfenidato"]` with an alphabetical fallback for other keys.
- Replace the direct `Object.entries(medicamentosAgrupados.estimulantes)` iteration with `estimulantesOrdenados.map(...)` so the UI renders the new ordered collection.
- Change is confined to `app/precios/page.tsx` and does not alter the grouping logic in `lib/medicamentos/utils.ts`.

### Testing
- Ran `npm run lint` which completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134a60e9ec832c915bfe55ebd65375)