### PR TITLE
Remove lisdexamfetamine theoretical coverage messaging

### DIFF
--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -49,10 +49,6 @@ function sortMedicamentosAlphabetically(items: Medicamento[]): Medicamento[] {
   });
 }
 
-function isLisdexanfetamina(medicamento: Medicamento): boolean {
-  return medicamento.nombre.toLowerCase().includes("lisdexanfetamina");
-}
-
 const priceTone = {
   stimulant: {
     heading: "text-emerald-700 dark:text-emerald-300",
@@ -391,28 +387,13 @@ export default function PreciosPage() {
                           <h3 className={`text-xl font-semibold mb-4 ${priceTone.stimulant.heading}`}>
                             <span className="capitalize">{principio}</span> ({meds.length} medicamentos)
                           </h3>
-                          {principio === "lisdexanfetamina" && (
-                            <Alert className="mb-4 border-amber-500/30 bg-amber-500/10">
-                              <AlertCircle className="h-4 w-4 text-amber-600" />
-                              <AlertDescription className="text-sm text-foreground">
-                                La lisdexanfetamina es nueva en Argentina. Las
-                                obras sociales y prepagas todavía no suelen
-                                cubrirla y no está incluida en el PMO. El precio
-                                con descuento es solo una referencia teórica.
-                              </AlertDescription>
-                            </Alert>
-                          )}
                           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                             {meds.map((medicamento) => (
                               <MedicationPriceCard
                                 key={medicamento.codigo}
                                 medicamento={medicamento}
                                 tone="stimulant"
-                                coverageLabel={
-                                  isLisdexanfetamina(medicamento)
-                                    ? "Precio teórico con 40% desc."
-                                    : "Con prepaga/obra social (40% desc.)"
-                                }
+                                coverageLabel="Con prepaga/obra social (40% desc.)"
                               />
                             ))}
                           </div>


### PR DESCRIPTION
### Motivation
- The prepaga discount is now applied to lisdexanfetamine so the special-case warning and the "precio teórico" wording are no longer accurate.
- Remove the visual/UX clutter and present a consistent coverage label for all stimulants.
- Keep the page logic simpler by removing an unused helper and conditional branches.

### Description
- Removed the `isLisdexanfetamina` helper and the lisdexanfetamine-specific `Alert` block from `app/precios/page.tsx`.
- Standardized the coverage label on stimulant cards to `"Con prepaga/obra social (40% desc.)"` so lisdexanfetamine uses the same text as other stimulants.
- Cleaned up the conditional code paths, leaving a single consistent `coverageLabel` for stimulant medication cards.
- Changes applied in `app/precios/page.tsx` and committed as `Remove lisdexamfetamine coverage warning`.

### Testing
- Ran `bun test` and all tests passed (`7 pass`, `0 fail`).
- Ran `bun run lint` and ESLint returned no warnings or errors.
- Ran `bun run build` and Next.js compiled and built successfully with static pages generated.
- Ran `git diff --check` and a quick grep to verify the removed warning text; no occurrences remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45db200d1c832cb1b47157017a7abc)